### PR TITLE
fixed crash when log_all_commands was set to true

### DIFF
--- a/src/Commands/Modules/BotOwner/ReloadCommand.cs
+++ b/src/Commands/Modules/BotOwner/ReloadCommand.cs
@@ -2,6 +2,7 @@
 using Qmmands;
 using Volte.Core.Attributes;
 using Volte.Core;
+using Volte.Commands.Results;
 
 namespace Volte.Commands.Modules
 {
@@ -12,7 +13,7 @@ namespace Volte.Commands.Modules
             "Reloads the bot's configuration file if you've changed it. NOTE: This will throw an exception if the config file is invalid JSON!")]
         [Remarks("reload")]
         [RequireBotOwner]
-        public Task ReloadAsync()
+        public Task<ActionResult> ReloadAsync()
             => Config.Reload(Context.ServiceProvider)
                 ? Ok("Config reloaded!")
                 : BadRequest("Something bad happened. Check console for more detailed information.");


### PR DESCRIPTION
Because it didn't contain an ActionResult it didn't get picked up by this switch statement

https://github.com/Ultz/Volte/blob/10d2e6847624bfb0c5d3b6b813f8d204c9e69a30/src/Services/CommandsService.cs#L34-L50

Which caused this to throw a null reference exception because data was previously set to null 

https://github.com/Ultz/Volte/blob/10d2e6847624bfb0c5d3b6b813f8d204c9e69a30/src/Services/CommandsService.cs#L72