### PR TITLE
SetStream & SetGame are now independant from each other

### DIFF
--- a/src/Commands/Modules/BotOwner/SetGameCommand.cs
+++ b/src/Commands/Modules/BotOwner/SetGameCommand.cs
@@ -1,7 +1,8 @@
-﻿using System.Threading.Tasks;
+﻿using Discord;
 using Qmmands;
-using Volte.Core.Attributes;
+using System.Threading.Tasks;
 using Volte.Commands.Results;
+using Volte.Core.Attributes;
 
 namespace Volte.Commands.Modules
 {
@@ -11,7 +12,12 @@ namespace Volte.Commands.Modules
         [Description("Sets the bot's game (presence).")]
         [Remarks("setgame {String}")]
         [RequireBotOwner]
-        public Task<ActionResult> SetGameAsync([Remainder] string game) 
-            => Ok($"Set the bot's game to **{game}**.", _ => Context.Client.SetGameAsync(game));
+        public Task<ActionResult> SetGameAsync([Remainder] string game)
+        {
+            var activity = Context.Client.Activity;
+            return Context.Client.Activity.Type == ActivityType.Streaming
+                ? Ok($"Set the bot's game to **{game}**.", _ => Context.Client.SetGameAsync(game, (activity as StreamingGame).Url, activity.Type))
+                : Ok($"Set the bot's game to **{game}**.", _ => Context.Client.SetGameAsync(game));
+        }
     }
 }

--- a/src/Commands/Modules/BotOwner/SetGameCommand.cs
+++ b/src/Commands/Modules/BotOwner/SetGameCommand.cs
@@ -15,8 +15,8 @@ namespace Volte.Commands.Modules
         public Task<ActionResult> SetGameAsync([Remainder] string game)
         {
             var activity = Context.Client.Activity;
-            return Context.Client.Activity.Type == ActivityType.Streaming
-                ? Ok($"Set the bot's game to **{game}**.", _ => Context.Client.SetGameAsync(game, (activity as StreamingGame).Url, activity.Type))
+            return Context.Client.Activity.Type is ActivityType.Streaming
+                ? Ok($"Set the bot's game to **{game}**.", _ => Context.Client.SetGameAsync(game, activity.Cast<StreamingGame>().Url, activity.Type))
                 : Ok($"Set the bot's game to **{game}**.", _ => Context.Client.SetGameAsync(game));
         }
     }

--- a/src/Commands/Modules/BotOwner/SetGameCommand.cs
+++ b/src/Commands/Modules/BotOwner/SetGameCommand.cs
@@ -1,4 +1,5 @@
 ﻿using Discord;
+using Gommon;
 using Qmmands;
 using System.Threading.Tasks;
 using Volte.Commands.Results;

--- a/src/Commands/Modules/BotOwner/SetStreamCommand.cs
+++ b/src/Commands/Modules/BotOwner/SetStreamCommand.cs
@@ -1,8 +1,9 @@
-﻿using System.Threading.Tasks;
-using Discord;
+﻿using Discord;
+using Gommon;
 using Qmmands;
-using Volte.Core.Attributes;
+using System.Threading.Tasks;
 using Volte.Commands.Results;
+using Volte.Core.Attributes;
 
 namespace Volte.Commands.Modules
 {
@@ -12,9 +13,15 @@ namespace Volte.Commands.Modules
         [Description("Sets the bot's stream via Twitch username and Stream name, respectively.")]
         [Remarks("setstream {String} {String}")]
         [RequireBotOwner]
-        public Task<ActionResult> SetStreamAsync(string streamer, [Remainder] string streamName)
-            => Ok(
-                $"Set the bot's stream to **{streamName}**, and the Twitch URL to **[{streamer}](https://twitch.tv/{streamer})**.",
-                _ => Context.Client.SetGameAsync(streamName, $"https://twitch.tv/{streamer}", ActivityType.Streaming));
+        public Task<ActionResult> SetStreamAsync(string stream, [Remainder] string game = null)
+        {
+            return !game.IsNullOrWhitespace()
+                ? Ok(
+                        $"Set the bot's game to **{game}**, and the Twitch URL to **[{stream}](https://twitch.tv/{stream})**.",
+                        _ => Context.Client.SetGameAsync(game, $"https://twitch.tv/{stream}", ActivityType.Streaming))
+                : Ok(
+                       $"Set the bot's stream URL to **[{stream}](https://twitch.tv/{stream})**.",
+                       _ => Context.Client.SetGameAsync(Context.Client.Activity.Name, $"https://twitch.tv/{stream}", ActivityType.Streaming));
+        }
     }
 }

--- a/src/Services/EventService.cs
+++ b/src/Services/EventService.cs
@@ -30,6 +30,9 @@ namespace Volte.Services
         private readonly bool _shouldStream =
             !Config.Streamer.IsNullOrWhitespace();
 
+        private readonly bool _shouldSetGame =
+            !Config.Game.IsNullOrWhitespace();
+
         public EventService(LoggingService loggingService,
             DatabaseService databaseService,
             AntilinkService antilinkService,
@@ -102,8 +105,11 @@ namespace Volte.Services
 
             if (!_shouldStream)
             {
-                await args.Shard.SetGameAsync(Config.Game);
-                _logger.Info(LogSource.Volte, $"Set {args.Shard.CurrentUser.Username}'s game to \"{Config.Game}\".");
+                if (_shouldSetGame)
+                {
+                    await args.Shard.SetGameAsync(Config.Game);
+                    _logger.Info(LogSource.Volte, $"Set {args.Shard.CurrentUser.Username}'s game to \"{Config.Game}\".");
+                }
             }
             else
             {

--- a/src/Services/EventService.cs
+++ b/src/Services/EventService.cs
@@ -28,7 +28,7 @@ namespace Volte.Services
         private readonly QuoteService _quoteService;
 
         private readonly bool _shouldStream =
-            !Config.Streamer.ContainsIgnoreCase(" ") || !Config.Streamer.IsNullOrEmpty();
+            !Config.Streamer.IsNullOrWhitespace();
 
         public EventService(LoggingService loggingService,
             DatabaseService databaseService,


### PR DESCRIPTION
**SetGame**
Used to overwrite the stream status when setting a game now it keeps the current status.

**SetStream**
Now you don't have to specify the game anymore and can keep the previous game while just changing the stream.

**EventService**
Now only sets the stream/game when it's actually specified in the config. 
_shouldStream previously evaluted to true when status_twitch_streamer was just whitespace and it still tried to set the stream.