### PR TITLE
fix: invalid timestamp parsing

### DIFF
--- a/src/Bot/Systems/Commands/Text/Parsers/TimeSpanParser.cs
+++ b/src/Bot/Systems/Commands/Text/Parsers/TimeSpanParser.cs
@@ -33,6 +33,9 @@ public partial class TimeSpanParser : VolteTypeParser<TimeSpan>
         if (match.Groups["Seconds"].Success && match.Groups["Seconds"].Value[r].TryParse<int>(out var seconds))
             result += seconds.Seconds();
 
+        if (match.Groups["0"].Success && result == TimeSpan.Zero)
+            return Failure($"\"{value}\" could not be interpreted as a valid time span.");
+
         return Success(result);
     }
         


### PR DESCRIPTION
Fix an error where the bot would create a reminder for current time + 0 when an invalid timestamp was provided, and return a descriptive error message instead.