### PR TITLE
feat: add Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /app
+
+COPY src/Bot ./
+RUN dotnet restore
+
+RUN dotnet publish -c Release -o out
+
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS runtime
+WORKDIR /app
+COPY --from=build /app/out ./
+
+CMD ["dotnet", "Volte.dll"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,8 @@
+services:
+  volte:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    volumes:
+      - ./data:/app/data


### PR DESCRIPTION
Add a `Dockerfile` to create a docker image for the `Bot` project. Since docker containers run in a Linux CLI, do not add the `UI` project to the image.

Additionally add a `docker-compose.yaml` that automatically builds the Docker image and sets up the proper volumes needed for data persistency.